### PR TITLE
Better support for Lumen

### DIFF
--- a/src/ZarinPalServiceProvider.php
+++ b/src/ZarinPalServiceProvider.php
@@ -14,7 +14,7 @@ class ZarinPalServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/../config/zarinpal.php' => $this->app->configPath().'/zarinpal.php',
+            __DIR__.'/../config/zarinpal.php' => config_path('zarinpal.php'),
         ], 'config');
     }
 


### PR DESCRIPTION
I get errror when implement package to lumen 5.5:
ZarinPalServiceProvider.php:
Call to undefined method Laravel\Lumen\Application::configPath()

but if you are using lumen, you could use https://github.com/irazasyed/larasupport and then use `config_path` helper.